### PR TITLE
Fix the bug that the morph association is empty and cannot be queried

### DIFF
--- a/src/Model/Concerns/QueriesRelationships.php
+++ b/src/Model/Concerns/QueriesRelationships.php
@@ -269,7 +269,7 @@ trait QueriesRelationships
         $types = (array) $types;
 
         if ($types === ['*']) {
-            $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->all();
+            $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
 
             foreach ($types as &$type) {
                 $type = Relation::getMorphedModel($type) ?? $type;


### PR DESCRIPTION
【修复】如果多态字段为false状态时，多态关联查询会报错，原因是没有过滤，laravel13天前已修复该bug。